### PR TITLE
Fix block json stringify decoding data on logs and instructions

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Decoding instruction and log data when not needed, leading to warning logs (#10)
 
 ## [6.0.2] - 2025-05-28
 ### Fixed

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -117,7 +117,6 @@ export class IndexerManager extends BaseIndexerManager<
     dataSources: SolanaProjectDs[],
     getVM: (d: SolanaProjectDs) => Promise<IndexerSandbox>,
   ): Promise<void> {
-    // console.time(`Indexed block ${block.blockHeight}`);
     await this.indexBlockContent(block, dataSources, getVM);
 
     for (const tx of block.transactions) {

--- a/packages/node/src/solana/api.solana.spec.ts
+++ b/packages/node/src/solana/api.solana.spec.ts
@@ -29,13 +29,10 @@ describe('Api.solana', () => {
   let solanaApi: SolanaApi;
   const eventEmitter = new EventEmitter2();
   let block: IBlock<SolanaBlock>;
+  const decoder = new SolanaDecoder();
 
   beforeAll(async () => {
-    solanaApi = await SolanaApi.create(
-      HTTP_ENDPOINT,
-      eventEmitter,
-      new SolanaDecoder(),
-    );
+    solanaApi = await SolanaApi.create(HTTP_ENDPOINT, eventEmitter, decoder);
     // https://solscan.io/block/325922873
     block = await solanaApi.fetchBlock(325_922_873);
   }, 20_000);
@@ -286,9 +283,11 @@ describe('Api.solana', () => {
         '4V5S9ymSheic34SsHN9AHA86b41qXfA9JwdEra1UUgoNdvWFTMA5ueSCHn6nRTBDphMQFUFLPgU4N2QsG8En3J1d',
       );
       const inst = tx?.transaction.message.instructions[4];
-
       expect(inst).toBeDefined();
+
+      const decodeInst = jest.spyOn(solanaApi.decoder, 'decodeInstruction');
       expect(() => JSON.stringify(inst)).not.toThrow();
+      expect(decodeInst).not.toHaveBeenCalled();
     });
 
     it('can stringify a LogMessage', () => {
@@ -297,7 +296,9 @@ describe('Api.solana', () => {
       );
 
       for (const log of tx!.meta!.logs!) {
+        const decodeLog = jest.spyOn(solanaApi.decoder, 'decodeLog');
         expect(() => JSON.stringify(log)).not.toThrow();
+        expect(decodeLog).not.toHaveBeenCalled();
       }
     });
   });

--- a/packages/node/src/solana/block.solana.ts
+++ b/packages/node/src/solana/block.solana.ts
@@ -34,6 +34,19 @@ type RawSolanaBlock = Readonly<{
   transactions: readonly TransactionForFullJson<0>[];
 }>;
 
+// We use this function to omit properties without accessing getters
+function omit<T>(input: T, omit: (keyof T)[]) {
+  const json: Record<string, any> = {};
+
+  for (const key of Object.getOwnPropertyNames(input)) {
+    if (!omit.includes(key as keyof T)) {
+      json[key] = (input as any)[key];
+    }
+  }
+
+  return json;
+}
+
 function wrapInstruction(
   index: number[],
   instruction: Omit<
@@ -59,8 +72,7 @@ function wrapInstruction(
 
   // Implement this in order to calculate block size
   (res as any).toJSON = () => {
-    const { block, decodedData, transaction, ...rest } = res;
-    return rest;
+    return omit(res, ['block', 'decodedData', 'transaction']);
   };
 
   return res;
@@ -148,8 +160,7 @@ function wrapLogs(
   // Implement this in order to calculate block size
   res.forEach((r) => {
     (r as any).toJSON = () => {
-      const { decodedMessage, ...rest } = r;
-      return rest;
+      return omit(r, ['decodedMessage']);
     };
   });
 
@@ -186,8 +197,7 @@ function wrapDictionaryLogs(
 
     // Implement this in order to calculate block size
     (res as any).toJSON = () => {
-      const { decodedMessage, ...rest } = res;
-      return rest;
+      return omit(res, ['decodedMessage']);
     };
 
     return res;

--- a/packages/node/src/solana/decoder.spec.ts
+++ b/packages/node/src/solana/decoder.spec.ts
@@ -14,7 +14,6 @@ const HTTP_ENDPOINT =
   process.env.HTTP_ENDPOINT ?? 'https://solana.api.onfinality.io/public';
 
 const IDL_Jupiter: IdlV01 = require('../../test/JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4.idl.json');
-const IDL_Meteora: RootNode = require('../../test/LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo.idl.json');
 const IDL_swap: IdlV01 = require('../../test/swapFpHZwjELNnjvThjajtiVmkz3yPQEHjLtka2fwHW.idl.json');
 const IDL_token: RootNode = require('../../test/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA.idl.json');
 

--- a/packages/node/src/solana/decoder.ts
+++ b/packages/node/src/solana/decoder.ts
@@ -67,7 +67,7 @@ function decodeData(
   const node = getEncodableNode(root, buffer);
   if (!node) {
     logger.warn(
-      `Failed to find instruction with discriminator ${data} in ${root.program.name}`,
+      `Failed to find instruction with discriminator in ${root.program.name}`,
     );
     return null;
   }

--- a/packages/node/src/solana/decoder.ts
+++ b/packages/node/src/solana/decoder.ts
@@ -67,7 +67,7 @@ function decodeData(
   const node = getEncodableNode(root, buffer);
   if (!node) {
     logger.warn(
-      `Failed to find instruction with discriminator in ${root.program.name}`,
+      `Failed to find instruction with discriminator ${data} in ${root.program.name}`,
     );
     return null;
   }


### PR DESCRIPTION
# Description
The `toJSON` methods on block data was causing the getters for decoded data to be triggered, this could lead to warnings being unable to decode data. This should also have some performance benefit.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
