### PR TITLE
Use customised version of unfinalized blocks service

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Unfinalized blocks not working (#16)
 
 ## [6.0.5] - 2025-07-24
 ### Changed

--- a/packages/node/src/blockchain.service.ts
+++ b/packages/node/src/blockchain.service.ts
@@ -84,12 +84,13 @@ export class BlockchainService
     // return 400; //Unit in MS
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async getHeaderForHash(hash: string): Promise<Header> {
-    return this.apiService.api.getHeaderByHeightOrHash(hash);
+    throw new Error('Solana doesnt support getting blocks by hash');
   }
 
   async getHeaderForHeight(height: number): Promise<Header> {
-    return this.apiService.api.getHeaderByHeightOrHash(height);
+    return this.apiService.api.getHeaderByHeight(height);
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await

--- a/packages/node/src/indexer/fetch.module.ts
+++ b/packages/node/src/indexer/fetch.module.ts
@@ -18,7 +18,6 @@ import {
   DsProcessorService,
   FetchService,
   DictionaryService,
-  UnfinalizedBlocksService,
   blockDispatcherFactory,
   MultiChainRewindService,
 } from '@subql/node-core';
@@ -26,6 +25,7 @@ import { BlockchainService } from '../blockchain.service';
 import { SolanaApiService } from '../solana/api.service.solana';
 import { SolanaDictionaryService } from './dictionary/dictionary.service';
 import { IndexerManager } from './indexer.manager';
+import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
 
 @Module({
   imports: [CoreModule],

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -22,7 +22,6 @@ import {
   SandboxService,
   DsProcessorService,
   DynamicDsService,
-  UnfinalizedBlocksService,
 } from '@subql/node-core';
 import {
   SolanaHandlerKind,
@@ -53,6 +52,7 @@ import {
   filterTransactionsProcessor,
 } from '../solana/utils.solana';
 import { BlockContent } from './types';
+import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
 
 @Injectable()
 export class IndexerManager extends BaseIndexerManager<

--- a/packages/node/src/indexer/unfinalizedBlocks.service.spec.ts
+++ b/packages/node/src/indexer/unfinalizedBlocks.service.spec.ts
@@ -1,0 +1,140 @@
+// Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import {
+  BlockUnavailableError,
+  Header,
+  IBlockchainService,
+  IStoreModelProvider,
+  NodeConfig,
+} from '@subql/node-core';
+import { UnfinalizedBlocksService } from './unfinalizedBlocks.service';
+
+const getMockStoreModelProvider = (): IStoreModelProvider => {
+  const meta: Record<string, any> = {};
+
+  return {
+    metadata: {
+      set: (key: string, value: any) => {
+        meta[key] = value;
+        return Promise.resolve();
+      },
+      find: (key) => Promise.resolve(meta[key]),
+    },
+    poi: null,
+  } as any;
+};
+
+const headerFromHeight = (
+  height: number,
+  finalized = false,
+  parentFinalized = false,
+): Header => ({
+  blockHeight: height,
+  blockHash: `0x${height}${finalized ? 'f' : ''}`,
+  parentHash: `0x${height - 1}${parentFinalized ? 'f' : ''}`,
+  timestamp: new Date('2025-08-27T23:07:53.486Z'),
+});
+
+const getMockBlockchainService = (
+  finalizedHeight = 100,
+  skippedSlots: number[] = [],
+): IBlockchainService & {
+  setFinalizedHeight: (newHeight: number) => void;
+  setSkippedSlots: (slots: number[]) => void;
+} => {
+  let _finalizedHeight = finalizedHeight;
+  let _skippedSlots = new Set(skippedSlots);
+
+  return {
+    getFinalizedHeader: () =>
+      Promise.resolve(headerFromHeight(_finalizedHeight, true)),
+    getHeaderForHeight: (height: number) => {
+      // Same behaviour as in SolanaApi
+      if (_skippedSlots.has(height)) {
+        // No block for that slot
+        throw new BlockUnavailableError();
+      }
+      return Promise.resolve(
+        headerFromHeight(
+          height,
+          height <= _finalizedHeight,
+          height < _finalizedHeight,
+        ),
+      );
+    },
+    setFinalizedHeight: (newHeight: number) => (_finalizedHeight = newHeight),
+    setSkippedSlots: (slots: number[]) => (_skippedSlots = new Set(slots)),
+  } as any;
+};
+
+describe('Unfinalized blocks', () => {
+  it('correctly detects forks', async () => {
+    const store = getMockStoreModelProvider();
+    const blockchain = getMockBlockchainService(100);
+    const unfinalizedBlocks = new UnfinalizedBlocksService(
+      new NodeConfig({} as any),
+      store,
+      blockchain,
+    );
+
+    const reindex = jest.fn();
+    await unfinalizedBlocks.init(reindex);
+
+    let height = 101;
+    const forkHeight = 108;
+    while (height <= 110) {
+      if (height === forkHeight) {
+        blockchain.setFinalizedHeight(forkHeight);
+        unfinalizedBlocks.registerFinalizedBlock(
+          headerFromHeight(forkHeight, true, true),
+        );
+      }
+      const rewindTo = await unfinalizedBlocks.processUnfinalizedBlockHeader(
+        await blockchain.getHeaderForHeight(height),
+      );
+      if (rewindTo) {
+        reindex(rewindTo);
+        break;
+      }
+      height++;
+    }
+
+    expect(reindex).toHaveBeenCalledWith(headerFromHeight(100, true, true));
+  });
+
+  it('handles block forks when there are missed slots', async () => {
+    const store = getMockStoreModelProvider();
+    const blockchain = getMockBlockchainService(100);
+    const unfinalizedBlocks = new UnfinalizedBlocksService(
+      new NodeConfig({} as any),
+      store,
+      blockchain,
+    );
+
+    const reindex = jest.fn();
+    await unfinalizedBlocks.init(reindex);
+
+    let height = 101;
+    const forkHeight = 108;
+    while (height <= 110) {
+      if (height === forkHeight) {
+        blockchain.setSkippedSlots([103]);
+        blockchain.setFinalizedHeight(forkHeight);
+        unfinalizedBlocks.registerFinalizedBlock(
+          headerFromHeight(forkHeight, true, true),
+        );
+      }
+      const rewindTo = await unfinalizedBlocks.processUnfinalizedBlockHeader(
+        await blockchain.getHeaderForHeight(height),
+      );
+      if (rewindTo) {
+        reindex(rewindTo);
+        break;
+      }
+      height++;
+    }
+
+    expect(reindex).toHaveBeenCalledWith(headerFromHeight(100, true, true));
+  });
+});

--- a/packages/node/src/indexer/unfinalizedBlocks.service.ts
+++ b/packages/node/src/indexer/unfinalizedBlocks.service.ts
@@ -1,0 +1,410 @@
+// Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
+// SPDX-License-Identifier: GPL-3.0
+
+import assert from 'assert';
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  IBlockchainService,
+  NodeConfig,
+  getLogger,
+  exitWithError,
+  mainThreadOnly,
+  ProofOfIndex,
+  PoiBlock,
+  IStoreModelProvider,
+  Header,
+  IBlock,
+  IUnfinalizedBlocksService,
+  BlockUnavailableError,
+} from '@subql/node-core';
+import { Transaction } from '@subql/x-sequelize';
+import { isEqual, last } from 'lodash';
+const logger = getLogger('UnfinalizedBlocks');
+
+export const METADATA_UNFINALIZED_BLOCKS_KEY = 'unfinalizedBlocks';
+export const METADATA_LAST_FINALIZED_PROCESSED_KEY =
+  'lastFinalizedVerifiedHeight';
+
+export const POI_NOT_ENABLED_ERROR_MESSAGE =
+  'Poi is not enabled, unable to check for last finalized block';
+
+const UNFINALIZED_THRESHOLD = 200;
+
+type UnfinalizedBlocks = Header[];
+
+// export interface IUnfinalizedBlocksService<B> extends IUnfinalizedBlocksServiceUtil {
+//   init(reindex: (targetHeader: Header) => Promise<void>): Promise<Header | undefined>;
+//   processUnfinalizedBlocks(block: IBlock<B> | undefined): Promise<Header | undefined>;
+//   processUnfinalizedBlockHeader(header: Header | undefined): Promise<Header | undefined>;
+//   resetUnfinalizedBlocks(tx?: Transaction): void;
+//   resetLastFinalizedVerifiedHeight(tx?: Transaction): void;
+//   getMetadataUnfinalizedBlocks(): Promise<UnfinalizedBlocks>;
+// }
+
+// export interface IUnfinalizedBlocksServiceUtil {
+//   registerFinalizedBlock(header: Header): void;
+// }
+
+@Injectable()
+export class UnfinalizedBlocksService<B = any>
+  implements IUnfinalizedBlocksService<B>
+{
+  private _unfinalizedBlocks?: UnfinalizedBlocks;
+  private _finalizedHeader?: Header;
+  protected lastCheckedBlockHeight?: number;
+
+  @mainThreadOnly()
+  private blockToHeader(block: IBlock<B>): Header {
+    return block.getHeader();
+  }
+
+  protected get unfinalizedBlocks(): UnfinalizedBlocks {
+    assert(
+      this._unfinalizedBlocks !== undefined,
+      new Error('Unfinalized blocks service has not been initialized'),
+    );
+    return this._unfinalizedBlocks;
+  }
+
+  protected get finalizedHeader(): Header {
+    assert(
+      this._finalizedHeader !== undefined,
+      new Error('Unfinalized blocks service has not been initialized'),
+    );
+    return this._finalizedHeader;
+  }
+
+  constructor(
+    protected readonly nodeConfig: NodeConfig,
+    @Inject('IStoreModelProvider')
+    protected readonly storeModelProvider: IStoreModelProvider,
+    @Inject('IBlockchainService')
+    protected blockchainService: IBlockchainService,
+  ) {}
+
+  async init(
+    reindex: (tagetHeader: Header) => Promise<void>,
+  ): Promise<Header | undefined> {
+    logger.info(
+      `Unfinalized blocks is ${
+        this.nodeConfig.unfinalizedBlocks ? 'enabled' : 'disabled'
+      }`,
+    );
+
+    this._unfinalizedBlocks = await this.getMetadataUnfinalizedBlocks();
+    this.lastCheckedBlockHeight = await this.getLastFinalizedVerifiedHeight();
+    this._finalizedHeader = await this.blockchainService.getFinalizedHeader();
+
+    if (this.unfinalizedBlocks.length) {
+      logger.info('Processing unfinalized blocks');
+      // Validate any previously unfinalized blocks
+
+      const rewindHeight = await this.processUnfinalizedBlocks();
+      if (rewindHeight !== undefined) {
+        logger.info(
+          `Found un-finalized blocks from previous indexing but unverified, rolling back to last finalized block ${rewindHeight}`,
+        );
+        await reindex(rewindHeight);
+        logger.info(`Successful rewind to block ${rewindHeight.blockHeight}!`);
+        return rewindHeight;
+      } else {
+        await this.resetUnfinalizedBlocks();
+        await this.resetLastFinalizedVerifiedHeight();
+      }
+    }
+  }
+
+  private get finalizedBlockNumber(): number {
+    return this.finalizedHeader.blockHeight;
+  }
+
+  async processUnfinalizedBlockHeader(
+    header?: Header,
+  ): Promise<Header | undefined> {
+    if (header) {
+      await this.registerUnfinalizedBlock(header);
+    }
+
+    const forkedHeader = await this.hasForked();
+
+    if (!forkedHeader) {
+      // Remove blocks that are now confirmed finalized
+      await this.deleteFinalizedBlock();
+    } else {
+      // Get the last unfinalized block that is now finalized
+      return this.getLastCorrectFinalizedBlock(forkedHeader);
+    }
+
+    return;
+  }
+
+  async processUnfinalizedBlocks(
+    block?: IBlock<B>,
+  ): Promise<Header | undefined> {
+    return this.processUnfinalizedBlockHeader(
+      block ? this.blockToHeader(block) : undefined,
+    );
+  }
+
+  registerFinalizedBlock(header: Header): void {
+    if (
+      this.finalizedHeader &&
+      this.finalizedBlockNumber >= header.blockHeight
+    ) {
+      return;
+    }
+    this._finalizedHeader = header;
+  }
+
+  private async registerUnfinalizedBlock(header: Header): Promise<void> {
+    if (header.blockHeight <= this.finalizedBlockNumber) return;
+
+    // Ensure order
+    const lastUnfinalizedHeight = last(this.unfinalizedBlocks)?.blockHeight;
+    if (
+      lastUnfinalizedHeight !== undefined &&
+      lastUnfinalizedHeight + 1 !== header.blockHeight
+    ) {
+      exitWithError(
+        `Unfinalized block is not sequential, lastUnfinalizedBlock='${lastUnfinalizedHeight}', newUnfinalizedBlock='${header.blockHeight}'`,
+        logger,
+      );
+    }
+
+    this.unfinalizedBlocks.push(header);
+    await this.saveUnfinalizedBlocks(this.unfinalizedBlocks);
+  }
+
+  private async deleteFinalizedBlock(): Promise<void> {
+    if (
+      this.lastCheckedBlockHeight !== undefined &&
+      this.lastCheckedBlockHeight < this.finalizedBlockNumber
+    ) {
+      this.removeFinalized(this.finalizedBlockNumber);
+      await this.saveLastFinalizedVerifiedHeight(this.finalizedBlockNumber);
+      await this.saveUnfinalizedBlocks(this.unfinalizedBlocks);
+    }
+    this.lastCheckedBlockHeight = this.finalizedBlockNumber;
+  }
+
+  // remove any records less and equal than input finalized blockHeight
+  private removeFinalized(blockHeight: number): void {
+    this._unfinalizedBlocks = this.unfinalizedBlocks.filter(
+      ({ blockHeight: height }) => height > blockHeight,
+    );
+  }
+
+  // find closest record from block heights
+  private getClosestRecord(blockHeight: number): Header | undefined {
+    // Have the block in the best block, can be verified
+    return [...this.unfinalizedBlocks] // Copy so we can reverse
+      .reverse() // Reverse the list to find the largest block
+      .find(({ blockHeight: height }) => height <= blockHeight);
+  }
+
+  // check unfinalized blocks for a fork, returns the header where a fork happened
+  protected async hasForked(): Promise<Header | undefined> {
+    const lastVerifiableBlock = this.getClosestRecord(
+      this.finalizedBlockNumber,
+    );
+
+    // No unfinalized blocks
+    if (!lastVerifiableBlock) {
+      return;
+    }
+
+    // Unfinalized blocks beyond finalized block
+    if (lastVerifiableBlock.blockHeight === this.finalizedBlockNumber) {
+      if (lastVerifiableBlock.blockHash !== this.finalizedHeader.blockHash) {
+        logger.warn(
+          `Block fork found, enqueued un-finalized block at ${lastVerifiableBlock.blockHeight} with hash ${lastVerifiableBlock.blockHash}, actual hash is ${this.finalizedHeader.blockHash}.`,
+        );
+        return this.finalizedHeader;
+      }
+    } else {
+      // Unfinalized blocks below finalized block
+      let header = this.finalizedHeader;
+      /*
+       * Iterate back through parent hashes until we get the header with the matching height
+       * We use headers here rather than getBlockHash because of potential caching issues on the rpc
+       * If we're off by a large number of blocks we can optimise by getting the block hash directly
+       */
+      if (
+        header.blockHeight - lastVerifiableBlock.blockHeight >
+        UNFINALIZED_THRESHOLD
+      ) {
+        header = await this.blockchainService.getHeaderForHeight(
+          lastVerifiableBlock.blockHeight,
+        );
+      } else {
+        while (lastVerifiableBlock.blockHeight !== header.blockHeight) {
+          assert(
+            header.parentHash,
+            'When iterate back parent hashes to find matching height, we expect parentHash to be exist',
+          );
+          // Solana doesn't support getting blocks by hash, so we use the previous block height
+          header = await this.getParentHeaderByHeight(header.blockHeight - 1);
+        }
+      }
+
+      if (header.blockHash !== lastVerifiableBlock.blockHash) {
+        logger.warn(
+          `Block fork found, enqueued un-finalized block at ${lastVerifiableBlock.blockHeight} with hash ${lastVerifiableBlock.blockHash}, actual hash is ${header.blockHash}`,
+        );
+        return header;
+      }
+    }
+
+    return;
+  }
+
+  protected async getLastCorrectFinalizedBlock(
+    forkedHeader: Header,
+  ): Promise<Header | undefined> {
+    const bestVerifiableBlocks = this.unfinalizedBlocks.filter(
+      ({ blockHeight }) => blockHeight <= this.finalizedBlockNumber,
+    );
+
+    let checkingHeader = forkedHeader;
+
+    // Work backwards through the blocks until we find a matching hash
+    for (const bestHeader of bestVerifiableBlocks.reverse()) {
+      if (
+        bestHeader.blockHash === checkingHeader.blockHash ||
+        bestHeader.blockHash === checkingHeader.parentHash
+      ) {
+        return bestHeader;
+      }
+
+      // Get the new parent
+      assert(
+        checkingHeader.parentHash,
+        'Expect checking header parentHash to be exist',
+      );
+      // Solana doesn't support getting blocks by hash, so we use the previous block height
+      checkingHeader = await this.getParentHeaderByHeight(
+        checkingHeader.blockHeight - 1,
+      );
+    }
+
+    if (!this.lastCheckedBlockHeight) {
+      return undefined;
+    }
+
+    return this.blockchainService.getHeaderForHeight(
+      this.lastCheckedBlockHeight,
+    );
+  }
+
+  // Finds the last POI that had a correct block hash, this is used with the Eth sdk
+  protected async findFinalizedUsingPOI(header: Header): Promise<Header> {
+    const poiModel = this.storeModelProvider.poi;
+    if (!poiModel) {
+      throw new Error(POI_NOT_ENABLED_ERROR_MESSAGE);
+    }
+
+    let lastHeight = header.blockHeight;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const indexedBlocks: ProofOfIndex[] = await poiModel.getPoiBlocksBefore(
+        lastHeight,
+      );
+
+      if (!indexedBlocks.length) {
+        break;
+      }
+
+      // Work backwards to find a block on chain that matches POI
+      for (const indexedBlock of indexedBlocks) {
+        const chainHeader = await this.blockchainService.getHeaderForHeight(
+          indexedBlock.id,
+        );
+
+        // Need to convert to PoiBlock to encode block hash to Uint8Array properly
+        const testPoiBlock = PoiBlock.create(
+          chainHeader.blockHeight,
+          chainHeader.blockHash,
+          new Uint8Array(),
+          indexedBlock.projectId ?? '',
+        );
+
+        // Need isEqual because of Uint8Array type
+        if (isEqual(testPoiBlock.chainBlockHash, indexedBlock.chainBlockHash)) {
+          return chainHeader;
+        }
+      }
+
+      // Next page of POI, use height rather than offset/limit as data could change in that time
+      lastHeight = indexedBlocks[indexedBlocks.length - 1].id - 1;
+    }
+
+    throw new Error('Unable to find a POI block with matching block hash');
+  }
+
+  private async saveUnfinalizedBlocks(
+    unfinalizedBlocks: UnfinalizedBlocks,
+  ): Promise<void> {
+    return this.storeModelProvider.metadata.set(
+      METADATA_UNFINALIZED_BLOCKS_KEY,
+      JSON.stringify(unfinalizedBlocks),
+    );
+  }
+
+  private async saveLastFinalizedVerifiedHeight(height: number): Promise<void> {
+    return this.storeModelProvider.metadata.set(
+      METADATA_LAST_FINALIZED_PROCESSED_KEY,
+      height,
+    );
+  }
+
+  async resetUnfinalizedBlocks(tx?: Transaction): Promise<void> {
+    await this.storeModelProvider.metadata.set(
+      METADATA_UNFINALIZED_BLOCKS_KEY,
+      '[]',
+      tx,
+    );
+    this._unfinalizedBlocks = [];
+  }
+
+  async resetLastFinalizedVerifiedHeight(tx?: Transaction): Promise<void> {
+    return this.storeModelProvider.metadata.set(
+      METADATA_LAST_FINALIZED_PROCESSED_KEY,
+      null as any,
+      tx,
+    );
+  }
+
+  //string should be jsonb object
+  async getMetadataUnfinalizedBlocks(): Promise<UnfinalizedBlocks> {
+    const val = await this.storeModelProvider.metadata.find(
+      METADATA_UNFINALIZED_BLOCKS_KEY,
+    );
+    if (val) {
+      const result: (Header & { timestamp: string })[] = JSON.parse(val);
+      return result.map(({ timestamp, ...header }) => ({
+        ...header,
+        timestamp: new Date(timestamp),
+      }));
+    }
+    return [];
+  }
+
+  async getLastFinalizedVerifiedHeight(): Promise<number | undefined> {
+    return this.storeModelProvider.metadata.find(
+      METADATA_LAST_FINALIZED_PROCESSED_KEY,
+    );
+  }
+
+  // Solana does not support getBlockHash and can skip blocks, so we work backwards
+  private async getParentHeaderByHeight(height: number): Promise<Header> {
+    try {
+      return await this.blockchainService.getHeaderForHeight(height);
+    } catch (e) {
+      if (e instanceof BlockUnavailableError) {
+        return this.getParentHeaderByHeight(height - 1);
+      }
+      throw e;
+    }
+  }
+}

--- a/packages/node/src/subcommands/reindex.module.ts
+++ b/packages/node/src/subcommands/reindex.module.ts
@@ -16,12 +16,12 @@ import {
   ConnectionPoolStateManager,
   DynamicDsService,
   DsProcessorService,
-  UnfinalizedBlocksService,
   MultiChainRewindService,
 } from '@subql/node-core';
 import { Sequelize } from '@subql/x-sequelize';
 import { BlockchainService } from '../blockchain.service';
 import { ConfigureModule } from '../configure/configure.module';
+import { UnfinalizedBlocksService } from '../indexer/unfinalizedBlocks.service';
 import { SolanaApiService } from '../solana';
 
 @Module({

--- a/packages/node/src/subcommands/testing.module.ts
+++ b/packages/node/src/subcommands/testing.module.ts
@@ -13,11 +13,11 @@ import {
   ProjectService,
   TestRunner,
   TestingCoreModule,
-  UnfinalizedBlocksService,
 } from '@subql/node-core';
 import { BlockchainService } from '../blockchain.service';
 import { ConfigureModule } from '../configure/configure.module';
 import { IndexerManager } from '../indexer/indexer.manager';
+import { UnfinalizedBlocksService } from '../indexer/unfinalizedBlocks.service';
 import { SolanaApiService } from '../solana';
 
 @Module({


### PR DESCRIPTION
# Description
Switch to using customized version of unfinalized blocks service. It does 2 things differently:
* Fetches headers by height rather than hash because solana doesn't have an RPC for this
* Handles when there are no blocks for a slot

Fixes https://github.com/subquery/subql/issues/2890

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
