### PR TITLE
Fix codegen types imports, add decoder logging

### DIFF
--- a/packages/node/src/solana/decoder.ts
+++ b/packages/node/src/solana/decoder.ts
@@ -192,12 +192,15 @@ export class SolanaDecoder {
         this.idls[programId] ?? (await this.getIdlFromChain(programId));
 
       if (!idl) {
+        logger.warn(
+          `Unable to decode instruction for program: ${programId}. No IDL.`,
+        );
         return null;
       }
 
       return decodeInstruction(idl, instruction.data);
     } catch (e) {
-      logger.debug(`Failed to decode instruction: ${e}`);
+      logger.warn(`Failed to decode instruction: ${e}`);
     }
 
     return null;
@@ -217,12 +220,13 @@ export class SolanaDecoder {
         this.idls[programId] ?? (await this.getIdlFromChain(programId));
 
       if (!idl) {
+        logger.warn(`Unable to decode log for program: ${programId}. No IDL.`);
         return null;
       }
 
       return decodeLog(idl, log.message);
     } catch (e) {
-      logger.debug(`Failed to decode log: ${e}`);
+      logger.warn(`Failed to decode log: ${e}`);
     }
     return null;
   }


### PR DESCRIPTION
# Description
- Work around codama bug that doesn't use granular imports for generated types
- Add logging to decoder to understand why data cannot be decoded

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
